### PR TITLE
External shredding algebra type members

### DIFF
--- a/src/main/scala/Expr.scala
+++ b/src/main/scala/Expr.scala
@@ -11,16 +11,16 @@ object types {
 
 import types._
 
-sealed trait Expr {
+sealed trait Expr[T] {
 
-  type Self <: Expr
-  type T
+  type Self <: Expr[T]
+//  type T
 
 //  def children: Seq[Expr[Nothing,Nothing]]
 
-  def eval: T = _eval(Map.empty)
-
-  def _eval(vars: BoundVars): T
+//  def eval: T = _eval(Map.empty)
+//
+//  def _eval(vars: BoundVars): T
 
 //  def shred[S,ES](implicit shredder: Shredder[T,S,Self,ES]): ES = shredder(this)
 
@@ -165,9 +165,9 @@ sealed trait VariableExpr[O] {
 }
 
 
-case class Variable[O](name: String) extends Expr with VariableExpr[O] with NullaryExpr {
+case class Variable[O](name: String) extends Expr[O] with VariableExpr[O] with NullaryExpr {
   type Self = Variable[O]
-  type T = O
+//  type T = O
   override def toString = s""""$name""""
 //  override def explain: String = s""""$name": $exprType"""
 //  override def replaceTypes(vars: Map[String, KeyType], overwrite: Boolean) = vars.get(name) match {
@@ -247,16 +247,16 @@ case class Variable[O](name: String) extends Expr with VariableExpr[O] with Null
 //}
 
 
-case class IntExpr(value: Int) extends Expr with PrimitiveExpr[Int] {
+case class IntExpr(value: Int) extends Expr[Int] with PrimitiveExpr[Int] {
   type Self = IntExpr
-  type T = Int
+//  type T = Int
   override def toString = s"$value"
 }
 
 
 case class PhysicalCollection[C[_,_],K,R](value: C[K,R])(implicit ev: Collection[C,K,R])
-  extends Expr with PrimitiveExpr[C[K,R]] {
-  type T = C[K,R]
+  extends Expr[C[K,R]] with PrimitiveExpr[C[K,R]] {
+//  type T = C[K,R]
   type Self = PhysicalCollection[C,K,R]
 }
 
@@ -378,14 +378,18 @@ case class PhysicalCollection[C[_,_],K,R](value: C[K,R])(implicit ev: Collection
 //  def _eval(vars: BoundVars) = dot(c1._eval(vars),c2._eval(vars))
 //}
 
-case class SelfDotExpr3[T1,E1 <: Expr,O](c1: E1, c2: E1)(implicit ev: c1.T =:= T1, dot: Dot[T1,T1,O])
-  extends Expr {
-  type Self = SelfDotExpr3[T1,E1,O]
-  type T = O
+case class SelfDotExpr3[T1,E[X] <: Expr[X],O](c1: E[T1], c2: E[T1])(implicit dot: Dot[T1,T1,O])
+  extends Expr[T1] {
+//  type Self = SelfDotExpr3[T1,E1]
+//  type T = O
   def opString = "⊙"
-  def _eval(vars: BoundVars) = dot(c1._eval(vars),c2._eval(vars))
+  def _eval(vars: BoundVars) = ??? //dot(c1._eval(vars),c2._eval(vars))
 }
 
+
+//trait FromExpr[T,E]
+//
+//implicit def
 
 //case class DotExpr[E1 <: Expr, E2 <: Expr,O](c1: E1, c2: E2)(implicit dot: Dot[c1.T,c2.T,O])
 ////(implicit dot: Dot[T1,T2,O])

--- a/src/main/scala/Expr.scala
+++ b/src/main/scala/Expr.scala
@@ -1,7 +1,8 @@
 package slender
 
 import algebra._
-//import slender.shredding.Shredder
+import slender.execution.Evaluator
+import slender.shredding.Shredder
 //import slender.shredding.Shredder
 
 
@@ -11,18 +12,13 @@ object types {
 
 import types._
 
-sealed trait Expr[T] {
-
-  type Self <: Expr[T]
-//  type T
+sealed trait Expr[Self <: Expr[Self]] { self : Self =>
 
 //  def children: Seq[Expr[Nothing,Nothing]]
 
-//  def eval: T = _eval(Map.empty)
-//
-//  def _eval(vars: BoundVars): T
+  def eval[T](implicit evaluator: Evaluator[Self,T]): T = evaluator(this,Map.empty)
 
-//  def shred[S,ES](implicit shredder: Shredder[T,S,Self,ES]): ES = shredder(this)
+  def shred[Shredded <: Expr[Shredded]](implicit shredder: Shredder[Self,Shredded]): Shredded = shredder(this)
 
   def id = hashCode.abs.toString.take(3).toInt
 
@@ -37,9 +33,6 @@ sealed trait Expr[T] {
 //  def labels: Seq[LabelExpr] =
 //    children.foldLeft(Seq.empty[LabelExpr])((acc,v) => acc ++ v.labels)
 //  def labelDefinitions: Seq[String] = labels.map(_.definition)
-
-  //def isResolved: Boolean = exprType.isResolved
-//  def isComplete: Boolean = freeVariables.isEmpty
 
 //  def brackets: (String,String) = ("","")
 //  def openString = toString
@@ -59,7 +52,7 @@ sealed trait Expr[T] {
 //  }
 }
 
-sealed trait NullaryExpr { //self : T =>
+sealed trait NullaryExpr[T <: NullaryExpr[T]] extends Expr[T] { //self : T =>
 //  def children = List.empty[Expr[Nothing,Nothing]]
 //  def renest = this
 //  def replaceTypes(vars: Map[String, KeyType], overwrite: Boolean) = this
@@ -103,11 +96,8 @@ sealed trait UnaryExpr[T] {
 
 
 
-sealed trait PrimitiveExpr[V] extends NullaryExpr {
+sealed trait PrimitiveExpr[E <: PrimitiveExpr[E,V],V] extends NullaryExpr[E] {
   def value: V
-  def _eval(vars: BoundVars) = value
-//  implicit def ev1: TypeTag[V]
-//  def literal = reify[V](value).tree
 }
 
 //case class PrimitiveKeyExpr[T](value: T)
@@ -159,15 +149,15 @@ sealed trait PrimitiveExpr[V] extends NullaryExpr {
 //}
 
 
-sealed trait VariableExpr[O] {
+sealed trait VariableExpr {
   //def matchTypes(keyType: KeyType): Map[String,KeyType]
-  def _eval(vars: BoundVars): O = ???
+//  def _eval(vars: BoundVars): O = ???
 }
 
+//sealed trait VariableName
 
-case class Variable[O](name: String) extends Expr[O] with VariableExpr[O] with NullaryExpr {
-  type Self = Variable[O]
-//  type T = O
+case class Variable[O](name: String) extends Expr[Variable[O]] with VariableExpr  {
+
   override def toString = s""""$name""""
 //  override def explain: String = s""""$name": $exprType"""
 //  override def replaceTypes(vars: Map[String, KeyType], overwrite: Boolean) = vars.get(name) match {
@@ -179,10 +169,10 @@ case class Variable[O](name: String) extends Expr[O] with VariableExpr[O] with N
 //  }
 //  override def variables = Set(this)
 //  override def freeVariables = Set(this)
-  override def _eval(vars: BoundVars): O = vars.get(this) match {
-    case v: Option[O] => v.get
-    case _ => throw new IllegalStateException()
-  }
+//  override def _eval(vars: BoundVars): O = vars.get(this) match {
+//    case v: Option[O] => v.get
+//    case _ => throw new IllegalStateException()
+//  }
 }
 
 
@@ -247,18 +237,11 @@ case class Variable[O](name: String) extends Expr[O] with VariableExpr[O] with N
 //}
 
 
-case class IntExpr(value: Int) extends Expr[Int] with PrimitiveExpr[Int] {
-  type Self = IntExpr
-//  type T = Int
-  override def toString = s"$value"
-}
+case class IntExpr(value: Int) extends Expr[IntExpr] with PrimitiveExpr[IntExpr,Int]
 
 
-case class PhysicalCollection[C[_,_],K,R](value: C[K,R])(implicit ev: Collection[C,K,R])
-  extends Expr[C[K,R]] with PrimitiveExpr[C[K,R]] {
-//  type T = C[K,R]
-  type Self = PhysicalCollection[C,K,R]
-}
+case class PhysicalCollection[C[_,_],K,R](value: C[K,R])//(implicit ev: Collection[C,K,R])
+  extends PrimitiveExpr[PhysicalCollection[C,K,R],C[K,R]]
 
 
 
@@ -378,12 +361,9 @@ case class PhysicalCollection[C[_,_],K,R](value: C[K,R])(implicit ev: Collection
 //  def _eval(vars: BoundVars) = dot(c1._eval(vars),c2._eval(vars))
 //}
 
-case class SelfDotExpr3[T1,E[X] <: Expr[X],O](c1: E[T1], c2: E[T1])(implicit dot: Dot[T1,T1,O])
-  extends Expr[T1] {
-//  type Self = SelfDotExpr3[T1,E1]
-//  type T = O
+case class SelfDotExpr[E <: Expr[E]](c1: E, c2: E)
+  extends Expr[SelfDotExpr[E]] {
   def opString = "⊙"
-  def _eval(vars: BoundVars) = ??? //dot(c1._eval(vars),c2._eval(vars))
 }
 
 

--- a/src/main/scala/algebra/Algebra.scala
+++ b/src/main/scala/algebra/Algebra.scala
@@ -31,7 +31,6 @@ object implicits {
     def apply(t1: Int, t2: Int): Int = t1 * t2
   }
 
-
   implicit object IntMultiply extends Multiply[Int, Int, Int] {
     def apply(t1: Int, t2: Int): Int = t1 * t2
   }
@@ -95,5 +94,4 @@ object implicits {
         t2.map { case (k2, v2) => (k1, k2) -> recur(v1, v2) }
       }
     }
-
 }

--- a/src/main/scala/execution/LocalEvaluator.scala
+++ b/src/main/scala/execution/LocalEvaluator.scala
@@ -1,14 +1,25 @@
-//package slender.execution
-//
-//import slender._
-//
-//object LocalEvaluator {
-//  def apply(expr: Expr[_]): Any = expr match {
-//    case p : PhysicalCollection[_,_] => { val x = eval(p); x
-//  }
-//
-//  def eval[K,V](p: PhysicalCollection[K,V]): Map[K,V] = p.phys
-//
-//
-//
-//}
+package slender.execution
+
+import slender._
+import slender.algebra.Dot
+import slender.types.BoundVars
+
+trait Evaluator[E <: Expr[E],T] extends ((E,BoundVars) => T)
+
+//todo with external evaluation, there is scope to put variables into the type system and then possibly
+//remove the need to tag them
+object implicits {
+
+  implicit def VariableEvaluator[T]: Evaluator[Variable[T],T] = new Evaluator[Variable[T],T] {
+    def apply(v1: Variable[T],v2: BoundVars): T = v2.get(v1).asInstanceOf[T]
+  }
+
+  implicit def PhysicalCollectionEvaluator[C[_,_],K,R]: Evaluator[PhysicalCollection[C,K,R],C[K,R]] = new Evaluator[PhysicalCollection[C,K,R],C[K,R]]{
+    def apply(v1: PhysicalCollection[C,K,R],v2:BoundVars): C[K,R] = v1.value
+  }
+
+  implicit def SelfDotEvaluator[E <: Expr[E],T,O](implicit evaluator: Evaluator[E,T], dot: Dot[T,T,O]):
+    Evaluator[SelfDotExpr[E],O] = new Evaluator[SelfDotExpr[E],O] {
+      def apply(v1: SelfDotExpr[E], v2: BoundVars): O = dot(evaluator(v1.c1,v2),evaluator(v1.c2,v2))
+  }
+}

--- a/src/main/scala/shredding.scala
+++ b/src/main/scala/shredding.scala
@@ -1,0 +1,37 @@
+package slender
+
+object shredding {
+
+//  def shred[T,E <: Expr[T],TS,ES <: Expr[TS]](expr: E)(implicit shredder: Shredder[T,E,TS,ES]): ES = shredder(expr)
+
+  trait Shredder[T <: Expr[T], S <: Expr[S]] extends (T => S)
+
+  trait NonShredder[T <: Expr[T]] extends Shredder[T,T] {
+    def apply(v1: T): T = v1
+  }
+
+  implicit def VariableShredder[K]: NonShredder[Variable[K]] = new NonShredder[Variable[K]] { }
+
+  implicit def PhysicalCollectionShredder[C[_,_],K,R]: NonShredder[PhysicalCollection[C,K,R]] =
+    new NonShredder[PhysicalCollection[C,K,R]] {}
+
+  implicit def SelfDotShredder[E <: Expr[E],ES <: Expr[ES]](implicit recur: Shredder[E,ES]): Shredder[SelfDotExpr[E],SelfDotExpr[ES]] =
+    new Shredder[SelfDotExpr[E],SelfDotExpr[ES]] {
+      def apply(v1: SelfDotExpr[E]): SelfDotExpr[ES] = SelfDotExpr(recur(v1.c1),recur(v1.c2))
+    }
+//
+//  implicit def DotShredder[T1,T1S,T2,T2S,E1[X]<:Expr[X],E1S[X] <: Expr[X],E2[X] <: Expr[X],E2S[X] <: Expr[X],O,OS](
+//                                                              implicit recur1: Shredder[T1,T1S,E1[T1],E1S[T1S]],
+//                                                              recur2: Shredder[T2,T2S,E2[T2],E2S[T2S]],
+//                                                              dot: Dot[T1S,T2S,OS]
+//                                                            ): Shredder[O,OS,DotExpr[T1,T2,E1,E2,O],DotExpr[T1S,T2S,E1S,E2S,OS]] =
+//    new Shredder[O,OS,DotExpr[T1,T2,E1,E2,O],DotExpr[T1S,T2S,E1S,E2S,OS]] {
+//      def apply(t: DotExpr[T1,T2,E1,E2,O]): DotExpr[T1S,T2S,E1S,E2S,OS] = DotExpr[T1S,T2S,E1S,E2S,OS](recur1(t.c1),recur2(t.c2))
+//    }
+
+//  implicit def BoxedRingShredder[O,OS, E <: Expr[O],ES <: Expr[ES]](implicit recur: Shredder[O,OS,E,ES]):
+//    Shredder[O,OS,BoxedRingExpr[O,E],LabelExpr[OS,ES]] = new Shredder[O,OS,BoxedRingExpr[O,E],LabelExpr[OS,ES]] {
+//      def apply(boxed: BoxedRingExpr[O,E]): LabelExpr[OS,ES] = LabelExpr(boxed.c1.shred)
+//    }
+
+}

--- a/src/test/scala/DslTest.scala
+++ b/src/test/scala/DslTest.scala
@@ -1,105 +1,131 @@
-package slender
-
-//import slender.dsl.implicits._
-import org.scalatest.FunSuite
-
-object collections {
-//  val stringCounts1 = PhysicalCollection(StringKeyType, IntType, "stringCounts1")
-//  val stringCounts2 = PhysicalCollection(StringKeyType, IntType, "stringCounts2")
-//  val bagOfBags = PhysicalBag(BoxedRingType(FiniteMappingType(StringKeyType, IntType)), "bagOfBags")
-//  val intCounts = PhysicalCollection(IntKeyType, IntType, "intCounts")
-//  val bagOfPairs = PhysicalBag(ProductKeyType(StringKeyType,IntKeyType), "bagOfPairs")
-//  val const = IntExpr(1)
-}
-
-class DslTests extends FunSuite {
-
-  import slender.algebra.dsl._
-  import slender.algebra.implicits._
-  import collections._
-
-//  test("Operators") {
-//    assert(
-//      stringCounts1 + stringCounts2 == Add(stringCounts1,stringCounts2) &&
-//      -Sum(stringCounts1) == Negate(Sum(stringCounts1)) &&
-//      stringCounts1 * stringCounts2 == Multiply(stringCounts1,stringCounts2) &&
-//      (stringCounts1 dot stringCounts2) == Dot(stringCounts1, stringCounts2) &&
-//      !Sum(stringCounts1) == Not(Sum(stringCounts1))
-//    )
-//  }
+//package slender
 //
-//  test("Simple for-comprehension") {
-//    val stringCounts1 = PhysicalCollection(Map("a" -> 1, "b" -> 2, "c" -> 3))
-//    val inner = "x".::[String] <-- stringCounts1
-//    val builder = For(inner)
-//    builde
+////import slender.dsl.implicits._
+//import org.scalatest.FunSuite
 //
-//    val query = For ("x".::[String] <-- (stringCounts1)) Collect 1
+//object collections {
+////  val stringCounts1 = PhysicalCollection(StringKeyType, IntType, "stringCounts1")
+////  val stringCounts2 = PhysicalCollection(StringKeyType, IntType, "stringCounts2")
+////  val bagOfBags = PhysicalBag(BoxedRingType(FiniteMappingType(StringKeyType, IntType)), "bagOfBags")
+////  val intCounts = PhysicalCollection(IntKeyType, IntType, "intCounts")
+////  val bagOfPairs = PhysicalBag(ProductKeyType(StringKeyType,IntKeyType), "bagOfPairs")
+////  val const = IntExpr(1)
+//}
+//
+//class DslTests extends FunSuite {
+//
+//  import slender.algebra.dsl._
+//  import slender.algebra.implicits._
+//  import collections._
+//
+////  test("Operators") {
+////    assert(
+////      stringCounts1 + stringCounts2 == Add(stringCounts1,stringCounts2) &&
+////      -Sum(stringCounts1) == Negate(Sum(stringCounts1)) &&
+////      stringCounts1 * stringCounts2 == Multiply(stringCounts1,stringCounts2) &&
+////      (stringCounts1 dot stringCounts2) == Dot(stringCounts1, stringCounts2) &&
+////      !Sum(stringCounts1) == Not(Sum(stringCounts1))
+////    )
+////  }
+////
+////  test("Simple for-comprehension") {
+////    val stringCounts1 = PhysicalCollection(Map("a" -> 1, "b" -> 2, "c" -> 3))
+////    val inner = "x".::[String] <-- stringCounts1
+////    val builder = For(inner)
+////    builde
+////
+////    val query = For ("x".::[String] <-- (stringCounts1)) Collect 1
+//////    assert(query.isTyped)
+//////    assert(query.exprType == IntType)
+//////    assert(query ==
+//////      Sum(stringCounts1 * {"x" ==> 1}).inferTypes
+////    println(query.eval)
+////  }
+////
+////  test("Nested for comprehension") {
+////    val nestedBag = Map(Map("a" -> 1)->1)
+////    val query = For ("x" <-- nestedBag) Collect "x".::[Map[String,Int]]
+////    println(query.eval)
+////  }
+////
+////  test("Simple yield") {
+////    val query = For ("x" <-- stringCounts1) Yield "x"
 ////    assert(query.isTyped)
-////    assert(query.exprType == IntType)
+////    assert(query.exprType == FiniteMappingType(StringKeyType,IntType))
 ////    assert(query ==
-////      Sum(stringCounts1 * {"x" ==> 1}).inferTypes
-//    println(query.eval)
-//  }
-//
-//  test("Nested for comprehension") {
-//    val nestedBag = Map(Map("a" -> 1)->1)
-//    val query = For ("x" <-- nestedBag) Collect "x".::[Map[String,Int]]
-//    println(query.eval)
-//  }
-//
-//  test("Simple yield") {
-//    val query = For ("x" <-- stringCounts1) Yield "x"
-//    assert(query.isTyped)
-//    assert(query.exprType == FiniteMappingType(StringKeyType,IntType))
-//    assert(query ==
-//      Sum(stringCounts1 * {"x" ==> sng("x")}).inferTypes
-//    )
-//  }
-//
-//  test("Predicated yield") {
-//    val query = For ("x" <-- intCounts iff "x" === 1) Yield "x"
-//    assert(query.isTyped)
-//    assert(query.exprType == FiniteMappingType(IntKeyType,IntType))
-//    assert(query ==
-//      Sum(intCounts * {"x" ==> sng("x","x"===1)}).inferTypes
-//    )
-//  }
-//
-//  test("Flatten") {
-//    val query = For ("x" <-- bagOfBags) Collect fromK("x")
-//    assert(query.isTyped)
-//    assert(query.exprType == BagType(StringKeyType))
-//    assert(query ==
-//      Sum(bagOfBags * {"x" ==> fromK("x")}).inferTypes
-//    )
-//  }
-//
-////  test ("Ring nesting") {
+////      Sum(stringCounts1 * {"x" ==> sng("x")}).inferTypes
+////    )
+////  }
+////
+////  test("Predicated yield") {
+////    val query = For ("x" <-- intCounts iff "x" === 1) Yield "x"
+////    assert(query.isTyped)
+////    assert(query.exprType == FiniteMappingType(IntKeyType,IntType))
+////    assert(query ==
+////      Sum(intCounts * {"x" ==> sng("x","x"===1)}).inferTypes
+////    )
+////  }
+////
+////  test("Flatten") {
+////    val query = For ("x" <-- bagOfBags) Collect fromK("x")
+////    assert(query.isTyped)
+////    assert(query.exprType == BagType(StringKeyType))
+////    assert(query ==
+////      Sum(bagOfBags * {"x" ==> fromK("x")}).inferTypes
+////    )
+////  }
+////
+//////  test ("Ring nesting") {
+//////    val query =
+//////      For ("k" <-- bagOfPairs) Yield (
+//////        "k"._1 --> sng("k"._2)
+//////      )
+//////    assert(query.isTyped)
+//////    assert(query.exprType == FiniteMappingType(StringKeyType,BagType(IntKeyType)))
+//////  }
+////
+////  test ("Ring nesting 2") {
 ////    val query =
-////      For ("k" <-- bagOfPairs) Yield (
-////        "k"._1 --> sng("k"._2)
+////      For (("k1","k2") <-- bagOfPairs) Yield (
+////        "k1" --> sng("k2")
 ////      )
 ////    assert(query.isTyped)
 ////    assert(query.exprType == FiniteMappingType(StringKeyType,BagType(IntKeyType)))
 ////  }
-//
-//  test ("Ring nesting 2") {
-//    val query =
-//      For (("k1","k2") <-- bagOfPairs) Yield (
-//        "k1" --> sng("k2")
-//      )
-//    assert(query.isTyped)
-//    assert(query.exprType == FiniteMappingType(StringKeyType,BagType(IntKeyType)))
-//  }
-//
-////  test ("Key nesting") {
-////    val group: KeyExpr => RingExpr = k =>
-////      For ("k1" <-- bagOfPairs iff k === "k1"._1) Yield "k1"._2
 ////
-////    val query = For ("k" <-- bagOfPairs) Yield (
-////        ("k"._1, toK(group("k"._1)))
-////      )
+//////  test ("Key nesting") {
+//////    val group: KeyExpr => RingExpr = k =>
+//////      For ("k1" <-- bagOfPairs iff k === "k1"._1) Yield "k1"._2
+//////
+//////    val query = For ("k" <-- bagOfPairs) Yield (
+//////        ("k"._1, toK(group("k"._1)))
+//////      )
+//////
+//////    assert(query.isTyped)
+//////    assert(query.exprType ==
+//////      BagType(
+//////        (StringKeyType, BoxedRingType(BagType(IntKeyType)))
+//////      )
+//////    )
+//////  }
+////
+////  test("Make key expr test") {
+////    val query = For ("x" <-- intCounts iff "x" === 1) Yield ( ("x","x") )
+////    println(query.explain)
+////    assert(query.isTyped)
+////    assert(query.exprType == FiniteMappingType((IntKeyType,IntKeyType),IntType))
+////    assert(query ==
+////      Sum(intCounts * {"x" ==> sng(("x","x"),"x"===1)}).inferTypes
+////    )
+////  }
+////
+////  test ("Key nesting 2") {
+////    val group: KeyExpr => RingExpr = k =>
+////      For (("k11","k22") <-- bagOfPairs iff k === "k11") Yield "k22"
+////
+////    val query = For (("k1","k2") <-- bagOfPairs) Yield (
+////      ("k1", toK(group("k1")))
+////    )
 ////
 ////    assert(query.isTyped)
 ////    assert(query.exprType ==
@@ -108,41 +134,15 @@ class DslTests extends FunSuite {
 ////      )
 ////    )
 ////  }
-//
-//  test("Make key expr test") {
-//    val query = For ("x" <-- intCounts iff "x" === 1) Yield ( ("x","x") )
-//    println(query.explain)
-//    assert(query.isTyped)
-//    assert(query.exprType == FiniteMappingType((IntKeyType,IntKeyType),IntType))
-//    assert(query ==
-//      Sum(intCounts * {"x" ==> sng(("x","x"),"x"===1)}).inferTypes
-//    )
-//  }
-//
-//  test ("Key nesting 2") {
-//    val group: KeyExpr => RingExpr = k =>
-//      For (("k11","k22") <-- bagOfPairs iff k === "k11") Yield "k22"
-//
-//    val query = For (("k1","k2") <-- bagOfPairs) Yield (
-//      ("k1", toK(group("k1")))
-//    )
-//
-//    assert(query.isTyped)
-//    assert(query.exprType ==
-//      BagType(
-//        (StringKeyType, BoxedRingType(BagType(IntKeyType)))
-//      )
-//    )
-//  }
-//
-//  test("Untyped query") {
-//    val query = For ("x" <-- bagOfBags) Yield (
-//      For ("y" <-- "x") Yield (
-//        "y" --> sng("z")
-//      )
-//    )
-//    assert(!query.isTyped)
-//    val typedQuery = query.inferTypes(Map("z" -> StringKeyType))
-//    assert(typedQuery.isTyped)
-//  }
-}
+////
+////  test("Untyped query") {
+////    val query = For ("x" <-- bagOfBags) Yield (
+////      For ("y" <-- "x") Yield (
+////        "y" --> sng("z")
+////      )
+////    )
+////    assert(!query.isTyped)
+////    val typedQuery = query.inferTypes(Map("z" -> StringKeyType))
+////    assert(typedQuery.isTyped)
+////  }
+//}

--- a/src/test/scala/EvaluatorTest.scala
+++ b/src/test/scala/EvaluatorTest.scala
@@ -37,6 +37,7 @@ class EvaluatorTests extends FunSuite {
 //    val query = SelfDotExpr(stringCounts1,stringCounts2)(productDots[String,String,Int,Int,Int](IntDot))
 //    val query2 = SelfDotExpr2[Map[String,Int],PhysicalCollection[Map,String,Int],Map[(String,String),Int]](stringCounts1,stringCounts2)
     val query3 = SelfDotExpr3(stringCounts1,stringCounts2)
+
 //    val query22 = SelfDotExpr2(stringCounts1,stringCounts2)
 //    val query3 = SelfDotExpr2(IntExpr(1),IntExpr(1))
 //    query3
@@ -46,8 +47,8 @@ class EvaluatorTests extends FunSuite {
 //    val result2 = query2.eval
 //    println(result)
 //    println(result2)
-      val result3 = query3.eval
-    println(result3)
+      //val result3 = query3.eval
+    //println(result3)
 //    query2
   }
 

--- a/src/test/scala/EvaluatorTest.scala
+++ b/src/test/scala/EvaluatorTest.scala
@@ -2,6 +2,9 @@ package slender
 
 import org.scalatest.FunSuite
 import slender.algebra.implicits._
+import slender.execution.implicits._
+import slender.shredding._
+
 import org.apache.spark.sql.SparkSession
 import slender.algebra.{Dot, PairRDD}
 
@@ -36,8 +39,15 @@ class EvaluatorTests extends FunSuite {
   test("Dot test") {
 //    val query = SelfDotExpr(stringCounts1,stringCounts2)(productDots[String,String,Int,Int,Int](IntDot))
 //    val query2 = SelfDotExpr2[Map[String,Int],PhysicalCollection[Map,String,Int],Map[(String,String),Int]](stringCounts1,stringCounts2)
-    val query3 = SelfDotExpr3(stringCounts1,stringCounts2)
+      val query3 = SelfDotExpr(stringCounts1,stringCounts2)
+      val result = query3.eval
+      println(result)
 
+      println(query3.shred.eval)
+
+
+
+//      query3
 //    val query22 = SelfDotExpr2(stringCounts1,stringCounts2)
 //    val query3 = SelfDotExpr2(IntExpr(1),IntExpr(1))
 //    query3

--- a/src/test/scala/ShreddingTest.scala
+++ b/src/test/scala/ShreddingTest.scala
@@ -3,7 +3,7 @@
 //import slender.dsl.implicits._
 //import definitions._
 //import org.scalatest.FunSuite
-//
+//E
 //
 //class ShreddingTests extends FunSuite {
 //


### PR DESCRIPTION
it’s now clear that external shredding can work, if evaluation is additionally made external so that the typeclass resolution for evaluation does not get in the way of node construction. pulling the POC of this back into the original external-shredding branch.